### PR TITLE
Add lsd as alternative to exa / ls

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
   </h1>
   <p align="center">A compatible, modern replacement for <code>ls</code>.</p>
   <p align="center">
-    <img src="https://raw.githubusercontent.com/Peltoche/lsd/assets/screen_lsd.png" width="700" />
+    <img src="https://raw.githubusercontent.com/Peltoche/lsd/assets/screen_lsd.png" width="600" />
   </p>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@
 
 <p align="center">
   <h1 align="center">
+    <a href="https://github.com/Peltoche/lsd"><code>lsd</code></a>
+  </h1>
+  <p align="center">A compatible, modern replacement for <code>ls</code>.</p>
+  <p align="center">
+    <img src="https://raw.githubusercontent.com/Peltoche/lsd/assets/screen_lsd.png" width="700" />
+  </p>
+</p>
+
+<p align="center">
+  <h1 align="center">
     <a href="https://github.com/bootandy/dust"><code>dust</code></a>
   </h1>
   <p align="center">A more intutive version of <code>du</code> written in rust.</p>


### PR DESCRIPTION
`lsd` is a command similar to `ls` but has great compatibility with `ls` allowing direct aliasing as a replacement. As a result, I recommend including it in the list of options.