### PR TITLE
Add dog - commandline DNS client

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,6 @@
   </h1>
   <p align="center">A user-friendly command-line DNS client. <code>dig</code> on steroids</p>
   <p align="center">
-    <img src="https://raw.githubusercontent.com/ogham/dog/master/dog-screenshot.png" width="600" />
+    <img src="https://raw.githubusercontent.com/ogham/dog/master/dog-screenshot.png" width="700" />
   </p>
 </p>

--- a/README.md
+++ b/README.md
@@ -271,3 +271,13 @@
     <img src="https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/contrib/tutorial.webp" width="600" />
   </p>
 </p>
+
+<p align="center">
+  <h1 align="center">
+    <a href="https://github.com/ogham/dog"><code>dog</code></a>
+  </h1>
+  <p align="center">A user-friendly command-line DNS client. <code>dig</code> on steroids</p>
+  <p align="center">
+    <img src="https://raw.githubusercontent.com/ogham/dog/master/dog-screenshot.png" width="600" />
+  </p>
+</p>


### PR DESCRIPTION
Include `dog` - a DNS client CLI that is friendlier than `dig`.