### PR TITLE
fix: replace the unmaintained exa with eza

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <p align="center">
   <h1 align="center">
-    <a href="https://github.com/ogham/exa"><code>exa</code></a>
+    <a href="https://github.com/eza-community/eza"><code>eza</code></a>
   </h1>
   <p align="center">A modern replacement for <code>ls</code>.</p>
   <p align="center">


### PR DESCRIPTION
**Description**

As noted by the developer, exa is no longer maintained - https://github.com/ogham/exa/issues/1243
And It is recommended to use [eza](https://github.com/eza-community/eza) as an alternative.

**References**

- https://github.com/ogham/exa?tab=readme-ov-file#exa-is-unmaintained-use-the-fork-eza-instead
- https://github.com/ogham/exa/issues/1243